### PR TITLE
Add GitHub Pages trial program

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,3 +123,7 @@ AVG by design, minimaliseer persoonsgegevens en definieer bewaartermijnen
 Documenten worden versleuteld opgeslagen, transport via TLS
 Alle acties worden in AuditLog vastgelegd
 Gebruik secrets via environment variables en rotation
+
+## GitHub Pages demo
+
+The file `index.html` with accompanying `script.js` demonstrates a minimal web page for testing in GitHub Pages. It includes a placeholder for future integration with the AuditCase API.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Vastleggingsprogramma Trial</title>
+</head>
+<body>
+  <h1>Vastleggingsprogramma Demo</h1>
+  <p>This page demonstrates a basic front-end that will later connect to the AuditCase API.</p>
+  <button id="load-btn">Load Sample Data</button>
+  <pre id="output"></pre>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,14 @@
+// Placeholder for future AuditCase API bridge
+// In the future, replace the fetch URL with the real AuditCase endpoint
+
+async function fetchAuditCase() {
+  try {
+    // Simulated data until AuditCase API is available
+    const data = { message: 'Sample data from AuditCase placeholder' };
+    document.getElementById('output').textContent = JSON.stringify(data, null, 2);
+  } catch (err) {
+    document.getElementById('output').textContent = 'Error loading data';
+  }
+}
+
+document.getElementById('load-btn').addEventListener('click', fetchAuditCase);


### PR DESCRIPTION
## Summary
- Add simple `index.html` and `script.js` to demo AuditCase integration
- Document GitHub Pages demo in README for future API bridge

## Testing
- `node --check script.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_b_68ad7087146c832f8c1f5f61934353b2