### PR TITLE
feat: move login screen to separate page

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,4 +126,4 @@ Gebruik secrets via environment variables en rotation
 
 ## GitHub Pages demo
 
-The file `index.html` with accompanying `script.js` demonstrates a minimal web page for testing in GitHub Pages. It includes a placeholder for future integration with the AuditCase API.
+Open `login.html` to choose a user and then continue to `index.html` for the main application. These static pages include a placeholder for future integration with the AuditCase API.

--- a/index.html
+++ b/index.html
@@ -77,34 +77,12 @@
             pointer-events: none;
             opacity: 0.6;
         }
-        /* Login screen styles */
-        #login-screen {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            justify-content: center;
-            height: 100vh;
-        }
     </style>
 </head>
 <body class="bg-gray-100 font-sans">
 
-    <!-- Login Screen -->
-    <div id="login-screen">
-        <div class="bg-white p-8 rounded-lg shadow-md text-center w-full max-w-sm">
-            <h1 class="text-2xl font-bold text-gray-800 mb-4">Inloggen</h1>
-            <p class="text-gray-600 mb-6">Selecteer een gebruiker om in te loggen.</p>
-            <select id="user-select" class="w-full p-2 border border-gray-300 rounded-md mb-4">
-                <!-- Users will be populated here -->
-            </select>
-            <button id="btn-login" class="w-full bg-blue-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-blue-700 transition">
-                Login
-            </button>
-        </div>
-    </div>
-    
-    <!-- Main Application Container (initially hidden) -->
-    <div id="app-container" class="hidden">
+    <!-- Main Application Container -->
+    <div id="app-container">
         <!-- Dashboard Screen -->
         <div id="dashboard-screen" class="container mx-auto p-4 md:p-8">
              <header class="bg-white p-6 rounded-lg shadow-md">
@@ -434,12 +412,8 @@
 
             // --- DOM Element References ---
             const dom = {
-                loginScreen: document.getElementById('login-screen'),
-                appContainer: document.getElementById('app-container'),
                 dashboardScreen: document.getElementById('dashboard-screen'),
                 werkprogrammaScreen: document.getElementById('werkprogramma-screen'),
-                userSelect: document.getElementById('user-select'),
-                btnLogin: document.getElementById('btn-login'),
                 btnLogout: document.getElementById('btn-logout'),
                 userDisplayDashboard: document.getElementById('user-display-dashboard'),
                 userDisplayWerkprogramma: document.getElementById('user-display-werkprogramma'),
@@ -482,16 +456,18 @@
 
             // --- Initialization ---
             function init() {
-                Object.keys(users).forEach(userId => {
-                    dom.userSelect.appendChild(new Option(users[userId].name, userId));
-                });
-                
+                const storedUserId = localStorage.getItem('currentUser');
+                if (!storedUserId || !users[storedUserId]) {
+                    window.location.href = 'login.html';
+                    return;
+                }
+                currentUser = users[storedUserId];
+
                 const currentYear = new Date().getFullYear();
                 availableYears = [currentYear, currentYear - 1, currentYear - 2];
                 populateFiscalYears();
-                
+
                 // Event Listeners
-                dom.btnLogin.addEventListener('click', handleLogin);
                 dom.btnLogout.addEventListener('click', handleLogout);
                 dom.btnAddYear.addEventListener('click', handleAddYear);
                 dom.btnIb.addEventListener('click', () => setupClientSelection('ib'));
@@ -503,7 +479,7 @@
                 dom.btnBackToDashboard.addEventListener('click', showDashboard);
                 dom.btnExport.addEventListener('click', handleExport);
                 dom.importFile.addEventListener('change', handleImport);
-                
+
                 // Action button listeners
                 dom.btnSubmit.addEventListener('click', () => updateDossierStatus('ingediend', 'Dossier ingediend.'));
                 dom.btnReview.addEventListener('click', () => updateDossierStatus('gereviewd', 'Dossier gereviewd.'));
@@ -517,6 +493,12 @@
                         showToast("Een reden is verplicht om het dossier te heropenen.");
                     }
                 });
+
+                dom.userDisplayDashboard.textContent = `Ingelogd als: ${currentUser.name}`;
+                dom.userDisplayWerkprogramma.textContent = `Ingelogd als: ${currentUser.name}`;
+                dom.btnAddYear.classList.toggle('hidden', !permissions[currentUser.role].canAddYear);
+
+                showDashboard();
             }
 
             // --- Core Functions ---
@@ -528,25 +510,10 @@
                 });
             }
 
-            function handleLogin() {
-                const selectedUserId = dom.userSelect.value;
-                if (!selectedUserId) return;
-                currentUser = users[selectedUserId];
-                
-                dom.loginScreen.classList.add('hidden');
-                dom.appContainer.classList.remove('hidden');
-                showDashboard();
-                dom.userDisplayDashboard.textContent = `Ingelogd als: ${currentUser.name}`;
-                dom.userDisplayWerkprogramma.textContent = `Ingelogd als: ${currentUser.name}`;
-                dom.btnAddYear.classList.toggle('hidden', !permissions[currentUser.role].canAddYear);
-            }
-            
             function handleLogout() {
                 currentUser = null;
-                dom.appContainer.classList.add('hidden');
-                dom.loginScreen.classList.remove('hidden');
-                dom.clientSelectionContainer.classList.add('hidden');
-                setActiveButton(null, '.program-btn');
+                localStorage.removeItem('currentUser');
+                window.location.href = 'login.html';
             }
 
             function handleAddYear() {

--- a/login.html
+++ b/login.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Inloggen - Werkprogramma IB & VPB</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+        #login-screen {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            height: 100vh;
+        }
+    </style>
+</head>
+<body class="bg-gray-100 font-sans">
+    <div id="login-screen">
+        <div class="bg-white p-8 rounded-lg shadow-md text-center w-full max-w-sm">
+            <h1 class="text-2xl font-bold text-gray-800 mb-4">Inloggen</h1>
+            <p class="text-gray-600 mb-6">Selecteer een gebruiker om in te loggen.</p>
+            <select id="user-select" class="w-full p-2 border border-gray-300 rounded-md mb-4"></select>
+            <button id="btn-login" class="w-full bg-blue-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-blue-700 transition">Login</button>
+        </div>
+    </div>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const users = {
+                alice: { name: "Alice (Opsteller)", role: "opsteller" },
+                bob: { name: "Bob (Reviewer)", role: "reviewer" },
+                charlie: { name: "Charlie (Admin)", role: "admin" }
+            };
+            const userSelect = document.getElementById('user-select');
+            Object.keys(users).forEach(id => {
+                userSelect.appendChild(new Option(users[id].name, id));
+            });
+            document.getElementById('btn-login').addEventListener('click', () => {
+                const selected = userSelect.value;
+                if (!selected) return;
+                localStorage.setItem('currentUser', selected);
+                window.location.href = 'index.html';
+            });
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- split login UI into new `login.html`
- load logged-in user from localStorage in `index.html` and redirect to login when missing
- document new flow in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68adba06dd58832f8511b9d86c4ca87e