### PR TITLE
Preserve session after client selection and demo user dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ Gebruik secrets via environment variables en rotation
 Open `login.html` to sign in and then continue to `index.html` for the main application.
 Use one of the demo accounts:
 
-- `alice` / `password`
-- `bob` / `password`
-- `charlie` / `password`
+- `jan` / `password`
+- `piet` / `password`
+- `klaas` / `password`
 
 Wanneer er geen backend beschikbaar is, valt de loginpagina terug op deze lokale demo-accounts zodat je de UI kunt verkennen. Als de server draait (`npm start`), worden dezelfde gegevens gevalideerd via de API.

--- a/js/app.js
+++ b/js/app.js
@@ -78,6 +78,7 @@ document.addEventListener('DOMContentLoaded', () => {
       window.location.href = 'login.html';
       return;
     }
+    const storedUser = sessionStorage.getItem('currentUser');
     try {
       const res = await fetch('/api/me', {
         headers: { Authorization: `Bearer ${token}` },
@@ -85,9 +86,14 @@ document.addEventListener('DOMContentLoaded', () => {
       if (!res.ok) throw new Error('Unauthorized');
       const data = await res.json();
       currentUser = data.user;
+      sessionStorage.setItem('currentUser', JSON.stringify(data.user));
     } catch (err) {
-      window.location.href = 'login.html';
-      return;
+      if (storedUser) {
+        currentUser = JSON.parse(storedUser);
+      } else {
+        window.location.href = 'login.html';
+        return;
+      }
     }
 
     const currentYear = new Date().getFullYear();

--- a/js/login.js
+++ b/js/login.js
@@ -1,8 +1,8 @@
 document.addEventListener('DOMContentLoaded', () => {
   const fallbackUsers = {
-    alice: { password: 'password', name: 'Alice (Opsteller)', role: 'opsteller' },
-    bob: { password: 'password', name: 'Bob (Reviewer)', role: 'reviewer' },
-    charlie: { password: 'password', name: 'Charlie (Admin)', role: 'admin' },
+    jan: { password: 'password', name: 'Jan Jansen (Opsteller)', role: 'opsteller' },
+    piet: { password: 'password', name: 'Piet de Boer (Reviewer)', role: 'reviewer' },
+    klaas: { password: 'password', name: 'Klaas Visser (Admin)', role: 'admin' },
   };
 
   const form = document.getElementById('login-form');

--- a/login.html
+++ b/login.html
@@ -18,16 +18,17 @@
             <label
               for="username"
               class="block text-sm font-medium text-gray-700"
-              >Gebruikersnaam</label
+              >Gebruiker</label
             >
-            <input
+            <select
               id="username"
-              type="text"
               class="w-full p-2 border border-gray-300 rounded-md"
-              aria-label="Gebruikersnaam"
-              value="alice"
-              required
-            />
+              aria-label="Gebruiker"
+            >
+              <option value="jan">Jan Jansen (Opsteller)</option>
+              <option value="piet">Piet de Boer (Reviewer)</option>
+              <option value="klaas">Klaas Visser (Admin)</option>
+            </select>
           </div>
           <div class="text-left">
             <label

--- a/server.js
+++ b/server.js
@@ -5,9 +5,9 @@ const app = express();
 app.use(express.json());
 
 const users = {
-  alice: { password: 'password', name: 'Alice (Opsteller)', role: 'opsteller' },
-  bob: { password: 'password', name: 'Bob (Reviewer)', role: 'reviewer' },
-  charlie: { password: 'password', name: 'Charlie (Admin)', role: 'admin' },
+  jan: { password: 'password', name: 'Jan Jansen (Opsteller)', role: 'opsteller' },
+  piet: { password: 'password', name: 'Piet de Boer (Reviewer)', role: 'reviewer' },
+  klaas: { password: 'password', name: 'Klaas Visser (Admin)', role: 'admin' },
 };
 
 const sessions = new Map();


### PR DESCRIPTION
## Summary
- Use dropdown to select demo users with role labels
- Keep user session when API is unavailable and open werkprogramma directly
- Rename demo users to Dutch names and update documentation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68b1861d24a4832fb9200041665ade56